### PR TITLE
HTTPNetworkTransport/Add constructor that accepts URLSession object

### DIFF
--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -59,6 +59,18 @@ public class HTTPNetworkTransport: NetworkTransport {
     self.sendOperationIdentifiers = sendOperationIdentifiers
   }
   
+  /// Creates a network transport with the specified server URL and session.
+  ///
+  /// - Parameters:
+  ///   - url: The URL of a GraphQL server to connect to.
+  ///   - session: The session object for handling network tasks.
+  ///   - sendOperationIdentifiers: Whether to send operation identifiers rather than full operation text, for use with servers that support query persistence. Defaults to false.
+  public init(url: URL, session: URLSession, sendOperationIdentifiers: Bool = false) {
+    self.url = url
+    self.session = session
+    self.sendOperationIdentifiers = sendOperationIdentifiers
+  }
+  
   /// Send a GraphQL operation to a server and return a response.
   ///
   /// - Parameters:


### PR DESCRIPTION
In order to configure SSL Certificate pinning, we ned the Apollo Client to be configured with an HTTPNetworkTransport that has a Session with a delegate that handles the SSL Pinning process. This adds a constructor for the HTTPNetwork so a user can inject a custom configured URLSession object.